### PR TITLE
Design settings page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3,5 +3,12 @@
     "description": {
         "part1": "To get started, edit <1>src/App.js</1> and save to reload.",
         "part2": "Switch language between english and german using buttons above."
+    },
+    "settings": {
+        "title": "Settings",
+        "leaders-per-page": "Leaders per page",
+        "projects-per-page": "Projects per page",
+        "leader-comment-max-length": "Comment max length on leaders interviews",
+        "save": "Save"
     }
 }

--- a/frontend/src/Settings/Settings.css
+++ b/frontend/src/Settings/Settings.css
@@ -1,0 +1,7 @@
+.form-label {
+    margin-bottom: 10px;
+}
+
+.label-wrapper {
+    margin-right: 10px;
+}

--- a/frontend/src/Settings/Settings.tsx
+++ b/frontend/src/Settings/Settings.tsx
@@ -1,5 +1,29 @@
+import { Box, Button, Grid, TextField } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import "./Settings.css";
+
 function Settings() {
-    return <h1>Settings component</h1>
+    const { t } = useTranslation('translation',  {keyPrefix: 'settings'});
+    return (
+        <Box display="flex" flexDirection="column" alignItems="center">
+            <h2>{t('title')}</h2>
+            <Box component="form">
+                <Box display="flex" flexDirection="row" justifyContent="space-between" className="form-label">
+                    <p className="label-wrapper">{t('leaders-per-page')}</p>
+                    <TextField type="number"/>
+                </Box>
+                <Box display="flex" flexDirection="row" justifyContent="space-between" className="form-label">
+                    <p className="label-wrapper">{t('projects-per-page')}</p>
+                    <TextField type="number"/>
+                </Box>
+                <Box display="flex" flexDirection="row" justifyContent="space-between" className="form-label">
+                    <p className="label-wrapper">{t('leader-comment-max-length')}</p>
+                    <TextField type="number"/>
+                </Box>
+                <Button variant="contained">{t('save')}</Button>
+            </Box>
+        </Box>  
+    );
 }
 
 export default Settings;


### PR DESCRIPTION
Part of #13 

Translations for texts like "Save" or "Submit" could go to some "common" place (because they are used in various places of the app), but I think is better to do that later when the app shapes a bit more.