### PR TITLE
Handle request errors on Frontend. Closes #16

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -101,6 +101,10 @@
         "page_Network": {
             "title": "Network Error",
             "text": "Check your internet connection, please"
+        },
+        "page_404_client": {
+            "title": "Not Found Page (404)",
+            "text": "Type another page address, or just go to the /login page"
         }
     }
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -75,5 +75,32 @@
             "title": "Edit translations",
             "add": "Add \"{}\" translation"
         }
+    },
+
+    "errors": {
+        "page_500": {
+            "title": "Internal Server Error (500)",
+            "text": "Sorry, something went wrong with server.\nTry to reload site"
+        },
+        "page_400": {
+            "title": "Bad Request (400)",
+            "text": "Sorry, site have passed request with bad data.\nTry to reload site"
+        },
+        "page_404": {
+            "title": "Not Found Error (404)",
+            "text": "Sorry, server can't found requested data.\nTry to reload site"
+        },
+        "page_403": {
+            "title": "Forbidden (403)",
+            "text": "Sorry, you haven't enough rights to access this page.\nTry to reauthorize or ask admin about your rights."
+        },
+        "page_405": {
+            "title": "Method Not Allowed (405)",
+            "text": "Sorry, request is not allowed by server.\nTry to reload site"
+        },
+        "page_Network": {
+            "title": "Network Error",
+            "text": "Check your internet connection, please"
+        }
     }
 }

--- a/frontend/public/locales/ru/translation.json
+++ b/frontend/public/locales/ru/translation.json
@@ -58,6 +58,10 @@
         "page_Network": {
             "title": "Network Error",
             "text": "Check your internet connection, please"
+        },
+        "page_404_client": {
+            "title": "Not Found Page (404)",
+            "text": "Type another page address, or just go to the /login page"
         }
     }
 }

--- a/frontend/public/locales/ru/translation.json
+++ b/frontend/public/locales/ru/translation.json
@@ -32,5 +32,32 @@
         "submit_filter": "Применить",
         "add_leader": "Добавить лидера",
         "add_project": "Добавить проект"
+    },
+
+    "errors": {
+        "page_500": {
+            "title": "Internal Server Error (500)",
+            "text": "Sorry, something went wrong with server.\nTry to reload site"
+        },
+        "page_400": {
+            "title": "Bad Request (400)",
+            "text": "Sorry, site have passed request with bad data.\nTry to reload site"
+        },
+        "page_404": {
+            "title": "Not Found Error (404)",
+            "text": "Sorry, server can't found requested data.\nTry to reload site"
+        },
+        "page_403": {
+            "title": "Forbidden (403)",
+            "text": "Sorry, you haven't enough rights to access this page.\nTry to reauthorize or ask admin about your rights."
+        },
+        "page_405": {
+            "title": "Method Not Allowed (405)",
+            "text": "Sorry, request is not allowed by server.\nTry to reload site"
+        },
+        "page_Network": {
+            "title": "Network Error",
+            "text": "Check your internet connection, please"
+        }
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import ErrorPage from "./ErrorPage";
 
 function App() {
 
-  const [user, setUser] = React.useState(UserType.None)
+  const [user, setUser] = React.useState(UserType.Admin)
   // setUser later will be passed with props to the Login component for changing the user
   // at first when the site is loaded user must be UserType.None, and then it will be saved in cookies
 
@@ -50,6 +50,7 @@ function App() {
           <Route path='/users' element={<Users />}/>
           <Route path='/filters' element={<FilterTablePage formType="LEADER"/>}/> {/* route for testing FilterTablePage component */}
           <Route path='/error/:code' element={<ErrorPage/>}/>
+          <Route path='*' element={<Navigate to='/error/404_client'/>}/>
           </Routes>
         </Container>
       </Stack>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,10 +18,11 @@ import { Stack } from "@mui/system";
 import React from "react";
 import { MENU_WIDTH } from "./types/global";
 import FilterTablePage from "./FiltersTablePage";
+import ErrorPage from "./ErrorPage";
 
 function App() {
 
-  const [user, setUser] = React.useState(UserType.Admin)
+  const [user, setUser] = React.useState(UserType.None)
   // setUser later will be passed with props to the Login component for changing the user
   // at first when the site is loaded user must be UserType.None, and then it will be saved in cookies
 
@@ -38,7 +39,7 @@ function App() {
           <Route path='/catalog' element={<Catalog />}/>
           <Route path='/leader/:id' element={<Leader />}/>
           <Route path='/leaders' element={<LeadersList />}/>
-          <Route path='/login' element={<Login />}/>
+          <Route path='/login' element={<Login changeUser={setUser}/>}/>
           <Route path='/project/:id' element={<Project />}/>
           <Route path='/projects' element={<ProjectsList />}/>
           <Route path='/settings' element={<Settings />}/>
@@ -48,6 +49,7 @@ function App() {
           <Route path='/options' element={<Options />}/>
           <Route path='/users' element={<Users />}/>
           <Route path='/filters' element={<FilterTablePage formType="LEADER"/>}/> {/* route for testing FilterTablePage component */}
+          <Route path='/error/:code' element={<ErrorPage/>}/>
           </Routes>
         </Container>
       </Stack>

--- a/frontend/src/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Navigate, useParams } from 'react-router-dom'
+import { Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+export default function ErrorPage() {
+
+  const params = useParams()
+  const [ t ] = useTranslation('translation',
+      { keyPrefix: "errors.page_" + params.code})
+
+  if (params.code === '401' || params.code === '403') {
+    return <Navigate to='/login'/>
+  }
+  else {
+    return (
+      <div>
+        <Typography variant='h2'>
+          {t('title')}
+        </Typography>
+        <Typography variant="body1">
+          {t('text')}
+        </Typography>
+      </div>
+    )
+  }
+}

--- a/frontend/src/ErrorPage/index.tsx
+++ b/frontend/src/ErrorPage/index.tsx
@@ -1,0 +1,3 @@
+import ErrorPage from "./ErrorPage";
+
+export default ErrorPage

--- a/frontend/src/FiltersTablePage/FilterTablePage.tsx
+++ b/frontend/src/FiltersTablePage/FilterTablePage.tsx
@@ -5,7 +5,7 @@ import ClearIcon from '@material-ui/icons/Clear'
 import AddIcon from '@material-ui/icons/Add'
 import * as Test from './_testFunctions'
 import { NumberFilter, TextFilter, CheckboxFilter, ChoiceFilter, AutocompleteChoiceFilter, DateFilter, AnswerFilter, AnswerVariant } from './TypedFilters'
-import { getUsersList, getAnswersList, getObjectsList, getToponymsList, getFilteredTableData, TableData, makeNewObject } from "./requests";
+import { getUsersList, getAnswersList, getObjectsList, getToponymsList, getFilteredTableData, TableData, makeNewObject } from "./requests2API";
 import { useState, useEffect, useRef } from "react";
 import MainTable from "./MainTable";
 import { useImmer } from "use-immer"
@@ -49,33 +49,34 @@ function SingleFilter(props : SingleFilterProps) {
     const { id, text, type, answer_block_id, setFilter } = props
     const [active, setActive] = useState(true)
     const [variants, setVariants] = useState<AnswerVariant[]>([])
+    const navigate = useNavigate()
 
     useEffect(() => {
         switch (type) {
             case AnswerType.List :
                 if (answer_block_id !== undefined) {
-                    getAnswersList(answer_block_id).then((answers) => {
+                    getAnswersList(answer_block_id, navigate).then((answers) => {
                         setVariants(answers)
                     })
                 }
                 break
             case AnswerType.User :
-                getUsersList().then((users) => {
+                getUsersList(navigate).then((users) => {
                     setVariants(users)
                 })
                 break
             case AnswerType.Leader :
-                getObjectsList('LEADER').then((leaders) => {
+                getObjectsList('LEADER', navigate).then((leaders) => {
                     setVariants(leaders)
                 })
                 break
             case AnswerType.Project :
-                getObjectsList('PROJECT').then((leaders) => {
+                getObjectsList('PROJECT', navigate).then((leaders) => {
                     setVariants(leaders)
                 })
                 break
             case AnswerType.Location :
-                getToponymsList().then((toponyms) => {
+                getToponymsList(navigate).then((toponyms) => {
                     setVariants(toponyms)
                 })
         }
@@ -198,7 +199,7 @@ function FilterTablePage({ formType } : { formType: 'LEADER' | 'PROJECT' }) {
             form_type: formType,
             answer_filters: buf.toString("base64")
         }
-        getFilteredTableData(body).then((data) => {
+        getFilteredTableData(body, navigate).then((data) => {
             console.log("New Table data:", data)
             setTableData(data)
         })
@@ -297,7 +298,7 @@ function FilterTablePage({ formType } : { formType: 'LEADER' | 'PROJECT' }) {
             <Box>
                 <Button variant="contained" onClick={handleSubmitFilter} sx={{ m: 2 }}>{t('submit_filter')}</Button>
                 <Button variant="outlined" sx={{ m: 2 }} onClick={(event: React.MouseEvent) => {
-                    makeNewObject(formType).then((id) => {
+                    makeNewObject(navigate, formType).then((id) => {
                         const link = '/' + formType.toLowerCase() + '/' + id
                         navigate(link, { replace: true })
                     })

--- a/frontend/src/FiltersTablePage/MainTable.tsx
+++ b/frontend/src/FiltersTablePage/MainTable.tsx
@@ -5,7 +5,7 @@ import { Row, _getRows, _getColumns } from './_testFunctions'
 import { Box, styled } from '@mui/system'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TableData } from './requests'
+import { TableData } from './requests2API'
 
 const StyledTableCell = styled(TableCell)({
     fontSize: '11px',

--- a/frontend/src/FiltersTablePage/requests2API.ts
+++ b/frontend/src/FiltersTablePage/requests2API.ts
@@ -1,9 +1,9 @@
 import { AnswerVariant, AnswerFilter } from "./TypedFilters"
 import { SERVER_ADDRESS } from "../types/global"
-import { FormResponse } from './FilterTablePage'
 import { FormsResponse, ColumnGroup, Row } from './_testFunctions'
 import i18next, { i18n } from "i18next"
-import axios from "axios"
+import axios, { AxiosError } from "axios"
+import { NavigateFunction, useNavigate } from "react-router-dom"
 
 interface TranslatedText {
     [language: string]: string
@@ -30,7 +30,15 @@ export function getLanguage() {
     return i18next.language.split('-', 1)[0]
 }
 
-export async function getUsersList() : Promise<AnswerVariant[]> {
+export function handleError(navigate: NavigateFunction, error: AxiosError) {
+    if (error.response)
+        navigate('/error/' + error.response.status, { replace: true })
+    else {
+        navigate('/error/Network', { replace: true })
+    }
+}
+
+export async function getUsersList(navigate: NavigateFunction) : Promise<AnswerVariant[]> {
     return await axios.get(SERVER_ADDRESS + '/users', { withCredentials: true })
         .then((response) => {
             console.log("Users response:", response.status, response.data)
@@ -38,11 +46,13 @@ export async function getUsersList() : Promise<AnswerVariant[]> {
         })
         .catch((error) => {
             console.log(error)
+            const navigate = useNavigate()
+            handleError(navigate, error)
             return []
         })
 }
 
-export async function getAnswersList(questionId: number) : Promise<AnswerVariant[]> {
+export async function getAnswersList(questionId: number, navigate: NavigateFunction) : Promise<AnswerVariant[]> {
     return await axios.get(SERVER_ADDRESS + '/answer_block',
         { withCredentials: true, params: { id: questionId } })
         .then((response) => {
@@ -54,11 +64,12 @@ export async function getAnswersList(questionId: number) : Promise<AnswerVariant
         })
         .catch((error) => {
             console.log(error)
+            handleError(navigate, error)
             return []
         })
 }
 
-export async function getObjectsList(type: 'LEADER' | 'PROJECT') : Promise<AnswerVariant[]> {
+export async function getObjectsList(type: 'LEADER' | 'PROJECT', navigate: NavigateFunction) : Promise<AnswerVariant[]> {
     return await axios.get(SERVER_ADDRESS + '/forms',
         { withCredentials: true, params: { form_type: type, answer_filters: [] } })
         .then((response) => {
@@ -73,11 +84,12 @@ export async function getObjectsList(type: 'LEADER' | 'PROJECT') : Promise<Answe
         .catch((error) => {
             console.log("EEERRORRRORRR!")
             console.log(error)
+            handleError(navigate, error)
             return []
         })
 }
 
-export async function getToponymsList() : Promise<AnswerVariant[]> {
+export async function getToponymsList(navigate: NavigateFunction) : Promise<AnswerVariant[]> {
     return await axios.get(SERVER_ADDRESS + '/all_toponyms',
         { withCredentials: true})
         .then((response) => {
@@ -87,11 +99,13 @@ export async function getToponymsList() : Promise<AnswerVariant[]> {
         })
         .catch((error) => {
             console.log(error)
+            handleError(navigate, error)
             return []
         })
 }
 
-export async function getFilteredTableData(data: FiltersRequestData) : Promise<TableData> {
+export async function getFilteredTableData(data: FiltersRequestData,
+                    navigate: NavigateFunction) : Promise<TableData> {
 
     function stringify(value: string | number | boolean) : string {
         switch (typeof value) {
@@ -140,6 +154,7 @@ export async function getFilteredTableData(data: FiltersRequestData) : Promise<T
         })
         .catch((error) => {
             console.log("Error while requesting /forms:", error)
+            handleError(navigate, error)
             return {
                 column_groups: [],
                 rows: []
@@ -147,19 +162,18 @@ export async function getFilteredTableData(data: FiltersRequestData) : Promise<T
         })
 }
 
-export async function makeNewObject(formType: 'LEADER' | 'PROJECT', name?: string) {
+export async function makeNewObject(navigate: NavigateFunction,
+                formType: 'LEADER' | 'PROJECT', name?: string) : Promise<number> {
     return await axios.post(SERVER_ADDRESS + '/forms', {
         state: 'PLANNED',
         name: name ? name : "insert name here",
         form_type: formType,
         answers: []
     }, { withCredentials: true })
-    .then((response) => (response.data))
+    .then((response) => (response.data as number))
     .catch((error) => {
         console.log("Error while requesting /forms by POST request:", error)
-        return {
-            column_groups: [],
-            rows: []
-        }
+        handleError(navigate, error)
+        return -1
     })
 }

--- a/frontend/src/Leader/Leader.tsx
+++ b/frontend/src/Leader/Leader.tsx
@@ -3,18 +3,21 @@ import TEST_DATA from "./TEST_DATA";
 import { GetFormInfo} from "../Response/API2Front";
 import {useEffect, useState} from "react";
 import {ResponseDataInterface} from "../Response/ResponseData";
-import {Navigate, useParams} from "react-router-dom";
+import {Navigate, useParams, useNavigate} from "react-router-dom";
 import {useEffectOnce} from "./useEffectOnce";
 
 function Leader(): JSX.Element {
     const [loaded, setLoaded] = useState(false);
     const [data, setData] = useState(TEST_DATA);
     const params = useParams();
+
+    const navigate = useNavigate()
+
     console.log("rendering")
     useEffectOnce( () => {
         let id = params.id
         if (id !== undefined) {
-            GetFormInfo(+id as number).then((responseData) => {
+            GetFormInfo(+id as number, navigate).then((responseData) => {
                 setLoaded(true);
                 console.log(responseData)
                 setData(responseData);

--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -2,10 +2,12 @@ import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { Box, Button, IconButton, InputAdornment, TextField } from '@mui/material';
 import { SyntheticEvent, useState} from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { SERVER_ADDRESS } from '../types/global'
 import axios, {AxiosResponse} from "axios";
 import i18n from "../i18n";
+import { UserType } from '../types/global';
+import { handleError } from '../FiltersTablePage/requests2API'
 
 
 enum Status {
@@ -16,15 +18,18 @@ enum Status {
     SuccessfulLogIn
 }
 
-function Login() {
+function Login({ changeUser } : { changeUser: (userType: UserType) => void }) {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [status, setStatus] = useState(Status.Nothing);
   const {t} = useTranslation('translation', { keyPrefix: 'login' });
+
+  const navigate = useNavigate()
 
   function processResponse(res: AxiosResponse) {
       switch (res.status) {
           case 200: {
               setStatus(Status.SuccessfulLogIn)
+              changeUser(UserType.Admin)
               break;
           }
           case 400: {
@@ -65,6 +70,11 @@ function Login() {
       }
 
       axios.post(SERVER_ADDRESS + "/login", request, config).then(processResponse)
+        .catch((error) => {
+          console.log(error)
+          handleError(navigate, error)
+          return error
+        })
   }
 
   function errorBox(text: string, statusCode: Status) {

--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -29,7 +29,7 @@ function Login({ changeUser } : { changeUser: (userType: UserType) => void }) {
       switch (res.status) {
           case 200: {
               setStatus(Status.SuccessfulLogIn)
-              changeUser(UserType.Admin)
+              changeUser(UserType.Admin) // later must be setted by response
               break;
           }
           case 400: {

--- a/frontend/src/Project/Project.tsx
+++ b/frontend/src/Project/Project.tsx
@@ -3,17 +3,20 @@ import TEST_DATA from "../Leader/TEST_DATA";
 import { GetFormInfo} from "../Response/API2Front";
 import {useEffect, useState} from "react";
 import {ResponseDataInterface} from "../Response/ResponseData";
-import {Navigate, useParams} from "react-router-dom";
+import {useNavigate, useParams} from "react-router-dom";
 
 function Project(): JSX.Element {
     const [loaded, setLoaded] = useState(false);
     const [data, setData] = useState(TEST_DATA);
     const params = useParams();
+
+    const navigate = useNavigate()
+
     console.log("rendering")
     useEffect( () => {
         let id = params.id
         if (id !== undefined) {
-            GetFormInfo(+id as number).then((responseData) => {
+            GetFormInfo(+id as number, navigate).then((responseData) => {
                 setLoaded(true);
                 console.log(responseData)
                 setData(responseData);

--- a/frontend/src/Response/API2Front.tsx
+++ b/frontend/src/Response/API2Front.tsx
@@ -23,10 +23,11 @@ import {InputInfoInterface} from "./SimpleQuestions/InputInfo";
 import {DynamicTableInterface} from "./Table/DynamicTable";
 import {FixedTableInterface} from "./Table/FixedTable";
 import {RelationQuestionProps} from "./SimpleQuestions/RelationQuestion";
+import { NavigateFunction, useNavigate } from "react-router-dom";
 
-export async function GetFormInfo(id: number): Promise<ResponseDataInterface> {
+export async function GetFormInfo(id: number, navigate: NavigateFunction): Promise<ResponseDataInterface> {
     console.log("REQUEST")
-    const res_form = await getRequest("form_page", {id: id})
+    const res_form = await getRequest("form_page", {id: id}, navigate)
     const form = res_form.data as APIForm;
     console.log(form)
     return {
@@ -73,6 +74,9 @@ async function ProcessQuestion(question: APIQuestion, answers: Array<APIAnswer>)
         tags: [],
         id: answers.length > 0 ? answers[0].id : -1
     }
+
+    const navigate = useNavigate()
+
     switch (question.question_type) {
         case SimpleQuestionType.NUMBER: {
             let initialValue = answers.length > 0 ? answers[0].value : -1;
@@ -84,7 +88,8 @@ async function ProcessQuestion(question: APIQuestion, answers: Array<APIAnswer>)
         }
         case SimpleQuestionType.RELATION:
             const options_resp = await getRequest("forms_lightweight",
-                {form_type: question.relation_settings ? question.relation_settings.relation_type : "LEADER"})
+                {form_type: question.relation_settings ? question.relation_settings.relation_type : "LEADER"},
+                navigate)
             let options = options_resp.data as Array<APIOption>
             questionData = {
                 label: question.text,
@@ -99,14 +104,14 @@ async function ProcessQuestion(question: APIQuestion, answers: Array<APIAnswer>)
         case SimpleQuestionType.MULTIPLE_CHOICE: {
             let options: Array<APIOption>;
             if (question.question_type == SimpleQuestionType.MULTIPLE_CHOICE) {
-                const options_resp = await getRequest("answer_block", {id: question.answer_block_id})
+                const options_resp = await getRequest("answer_block", {id: question.answer_block_id}, navigate)
                 const block = options_resp.data as APIAnswerBlock
                 options = block.options.map((option) => {return option as APIOption})
             } else if (question.question_type == SimpleQuestionType.LOCATION) {
-                const options_resp = await getRequest("all_toponyms")
+                const options_resp = await getRequest("all_toponyms", {}, navigate)
                 options = options_resp.data as Array<APIOption>
             } else {
-                const options_resp = await getRequest("users")
+                const options_resp = await getRequest("users", {}, navigate)
                 options = options_resp.data as Array<APIOption>
             }
             console.log(options)
@@ -125,7 +130,8 @@ async function ProcessQuestion(question: APIQuestion, answers: Array<APIAnswer>)
             break;
         }
         case SimpleQuestionType.CHECKBOX: {
-            let options_resp = await getRequest("answer_block", {id: question.answer_block_id})
+            let options_resp = await getRequest("answer_block", {id: question.answer_block_id},
+                navigate)
             const block = options_resp.data as APIAnswerBlock
             const options = block.options
 

--- a/frontend/src/Response/APIRequests.ts
+++ b/frontend/src/Response/APIRequests.ts
@@ -1,8 +1,10 @@
 import axios, {AxiosResponse} from "axios";
 import { SERVER_ADDRESS } from '../types/global'
+import { handleError } from "../FiltersTablePage/requests2API"
+import { NavigateFunction } from "react-router-dom";
 
 
-export async function getRequest(endpoint: string, params: Object = {}): Promise<AxiosResponse<any, any>> {
+export async function getRequest(endpoint: string, params: Object = {}, navigate: NavigateFunction): Promise<AxiosResponse<any, any>> {
     let query = SERVER_ADDRESS + "/" + endpoint + "?"
     let key: keyof typeof params
     // for (key in params) {
@@ -11,12 +13,22 @@ export async function getRequest(endpoint: string, params: Object = {}): Promise
     return await axios.get(query, {
         withCredentials: true,
         params: params
-})
+    })
+        .catch((error) => {
+            console.log(error)
+            handleError(navigate, error)
+            return error
+        })
 }
 
-export async function postRequest(endpoint: string, params: Object): Promise<AxiosResponse<any, any>> {
+export async function postRequest(endpoint: string, params: Object, navigate: NavigateFunction): Promise<AxiosResponse<any, any>> {
     let query = SERVER_ADDRESS + "/" + endpoint
     return await axios.post(query, params, {
         withCredentials: true
     })
+        .catch((error) => {
+            console.log(error)
+            handleError(navigate, error)
+            return error
+        })
 }

--- a/frontend/src/Response/Response.tsx
+++ b/frontend/src/Response/Response.tsx
@@ -5,6 +5,7 @@ import {SyntheticEvent, useState} from "react";
 import {SimpleQuestionTypesList} from "./SimpleQuestions/SimpleQuestion";
 import {postRequest} from "./APIRequests";
 import {APIFormState} from "./APIObjects";
+import { useNavigate } from "react-router-dom";
 
 interface IndexedData {
     [key: number]: SimpleQuestionTypesList
@@ -15,6 +16,8 @@ function Response(responseData: ResponseDataInterface): JSX.Element {
     const [name, setName] = useState(responseData.title)
     const [state, setState] = useState(responseData.state.toString())
     const [deleted, setDeleted] = useState(false)
+
+    const navigate = useNavigate()
 
     const onItemChanged = (changedAnswer: SimpleQuestionTypesList) => {
         console.log("ONITEMCHANGED")
@@ -62,7 +65,7 @@ function Response(responseData: ResponseDataInterface): JSX.Element {
             id: id,
             answers: answers,
             deleted: deleted
-        }).then((response: any) => {
+        }, navigate).then((response: any) => {
             console.log(response)
         })
     }

--- a/frontend/src/Response/SimpleQuestions/RelationQuestion.tsx
+++ b/frontend/src/Response/SimpleQuestions/RelationQuestion.tsx
@@ -2,10 +2,11 @@ import React, {SyntheticEvent, useEffect, useState} from "react"
 import { Autocomplete, IconButton, TextField } from '@mui/material'
 import { Stack } from "@mui/system"
 import { AnswerVariant } from "../../FiltersTablePage/TypedFilters"
-import { getObjectsList, makeNewObject } from "../../FiltersTablePage/requests"
+import { getObjectsList, makeNewObject } from "../../FiltersTablePage/requests2API"
 import AddIcon from '@material-ui/icons/Add'
 import { CommonQuestionProperties } from "./common"
 import {APIOption} from "../APIObjects";
+import { useNavigate } from "react-router-dom"
 
 
 export interface RelationQuestionProps extends CommonQuestionProperties{
@@ -21,6 +22,8 @@ export default function RelationQuestion(props: {
     const [variants, setVariants] = useState<AnswerVariant[]>([])
     const [value, setValue] = useState<AnswerVariant>(questionData.initialValue as AnswerVariant)
     const [inputValue, setInputValue] = useState<string>(questionData.initialValue ? questionData.initialValue.name : "")
+    
+    const navigate = useNavigate()
 
     const handleChange = (event: SyntheticEvent, newValue: string | AnswerVariant | null) => {
         setValue(newValue as AnswerVariant)
@@ -39,20 +42,23 @@ export default function RelationQuestion(props: {
     }
 
     useEffect(() => {
-        getObjectsList(questionData.relType).then((response) => {
+        getObjectsList(questionData.relType, navigate).then((response) => {
             setVariants(response)
         })
     }, [])
 
     const handleAddObject = () => {
         if (variants.filter((v) => (v.name === inputValue)).length === 0) {
-            makeNewObject(questionData.relType, inputValue).then((newId) => {
+            makeNewObject(navigate, questionData.relType, inputValue).then((newId) => {
                 setVariants([...variants, {
                     id: newId,
                     name: inputValue
                 }])
                 let data = questionData
-                data.initialValue = newId
+                data.initialValue = {
+                    id: newId,
+                    name: inputValue
+                }
                 data.value = newId
                 setData(data)
                 props.onChange(data)

--- a/frontend/src/types/global.ts
+++ b/frontend/src/types/global.ts
@@ -1,5 +1,6 @@
 
-const SERVER_ADDRESS = window.location.origin + '/api'
+// const SERVER_ADDRESS = window.location.origin + '/api'
+const SERVER_ADDRESS = 'http://127.0.0.1:5000' + '/api'
 
 enum UserType {
     Admin,

--- a/frontend/src/types/global.ts
+++ b/frontend/src/types/global.ts
@@ -1,6 +1,6 @@
 
 // const SERVER_ADDRESS = window.location.origin + '/api'
-const SERVER_ADDRESS = 'http://127.0.0.1:5000' + '/api'
+const SERVER_ADDRESS = window.location.origin + '/api'
 
 enum UserType {
     Admin,

--- a/frontend/src/types/global.ts
+++ b/frontend/src/types/global.ts
@@ -1,5 +1,4 @@
 
-// const SERVER_ADDRESS = window.location.origin + '/api'
 const SERVER_ADDRESS = window.location.origin + '/api'
 
 enum UserType {


### PR DESCRIPTION
Add ErrorPage component, which is on _/error/[error_type]_ page and handles different request errors:
- for 401 and 403 request errors it navigates to _/login_ page
- for 500, 400, 404 and 405 errors it shows different messages and advice for solving them (advice isn't very useful yet, but they are easily editable). You also can easily add another error statuses to _translation.json_ files and then they will handle too
- also there are pages for Network Error (when site hasn't access to server) and for 404 Not Found Page error (when wrong path is given)