### PR TITLE
Add popup for adding leader/project on the main page and fix sorting table

### DIFF
--- a/backend/app/database/formatting_settings.py
+++ b/backend/app/database/formatting_settings.py
@@ -20,8 +20,8 @@ class FormattingSettings(Editable, FlaskApp().db.Model):
                                      default=None)
     _fixed_table_id = FlaskApp().db.Column('fixed_table_id', FlaskApp().db.ForeignKey('fixed_tables.id'), nullable=True,
                                            default=None)
-    _default_filter = FlaskApp().db.Column('default_filter', FlaskApp().db.Boolean(), default=False)
-
+    # _default_filter = FlaskApp().db.Column('default_filter', FlaskApp().db.Boolean(), default=False)
+    _default_filter = False
     _cached = None
 
     def __init__(self, block_sorting: int, block_id: int, table_row: int = None, table_id: int = None,

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -65,7 +65,23 @@
         "choose_filter": "Choose filter...",
         "submit_filter": "Submit filter",
         "add_leader": "Add leader",
-        "add_project": "Add project"
+        "add_project": "Add project",
+        "add_leader_dialog": {
+            "title": "Adding leader",
+            "body": "Enter new leader's name",
+            "exists": "This leader already exists in database",
+            "input_label": "New leader's name",
+            "cancel": "Cancel",
+            "create": "Create"
+        },
+        "add_project_dialog": {
+            "title": "Adding project",
+            "body": "Enter new lprojects's name",
+            "exists": "This project already exists in database",
+            "input_label": "New project's name",
+            "cancel": "Cancel",
+            "create": "Create"
+        }
     },
 
     "options": {

--- a/frontend/public/locales/ru/translation.json
+++ b/frontend/public/locales/ru/translation.json
@@ -31,7 +31,23 @@
         "choose_filter": "Новый фильтр...",
         "submit_filter": "Применить",
         "add_leader": "Добавить лидера",
-        "add_project": "Добавить проект"
+        "add_project": "Добавить проект",
+        "add_leader_dialog": {
+            "title": "Добавление лидера",
+            "body": "Введите имя нового лидера",
+            "exists": "Лидер с таким именем уже есть в базе данных",
+            "input_label": "Имя нового лидера",
+            "cancel": "Отмена",
+            "create": "Создать"
+        },
+        "add_project_dialog": {
+            "title": "Добавление проекта",
+            "body": "Введите название нового проекта",
+            "exists": "Проект с таким названием уже есть в базе данных",
+            "input_label": "Название нового проекта",
+            "cancel": "Отмена",
+            "create": "Создать"
+        }
     },
 
     "dynamic_table": {
@@ -78,5 +94,4 @@
             "text": "Type another page address, or just go to the /login page"
         }
     }
-}
 }

--- a/frontend/src/FiltersTablePage/AddObjectPopup.tsx
+++ b/frontend/src/FiltersTablePage/AddObjectPopup.tsx
@@ -1,0 +1,99 @@
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useTranslation } from 'react-i18next';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AnswerVariant } from './TypedFilters';
+import { getObjectsList } from './requests2API';
+import { TextField, Autocomplete, Typography, Button } from '@mui/material';
+import React from 'react'
+
+interface AddObjectPopupProps {
+    formType: 'LEADER' | 'PROJECT'
+    onSubmit: (name: string) => void
+    onCancel: () => void
+}
+
+export default function AddObjectPopup(props : AddObjectPopupProps) {
+    const [variants, setVariants] = useState<AnswerVariant[]>([])
+    const [value, setValue] = useState<AnswerVariant>({name: "", id: -1})
+    const [inputValue, setInputValue] = useState<string>("")
+    const [exists, setExists] = useState<boolean>(false)
+
+    const navigate = useNavigate()
+
+    const handleChange = (event: React.SyntheticEvent, newValue: string | AnswerVariant | null) => {
+        setValue(newValue as AnswerVariant)
+        setExists(true)
+    }
+
+    const handleInputChange = (event: React.SyntheticEvent, newInputValue: string | null) => {
+        if (newInputValue !== null) {
+            setInputValue(newInputValue as string)
+            if (variants.filter((v) => (v.name === newInputValue)).length === 0) {
+                setExists(false)
+            }
+        }
+    }
+
+    useEffect(() => {
+        getObjectsList(props.formType, navigate).then((response) => {
+            setVariants(response)
+        })
+    }, [])
+    const {t} = useTranslation("translation", { keyPrefix: "filters." + 
+                ( props.formType === 'LEADER' ? 'add_leader_dialog' : 'add_project_dialog' )})
+
+
+    const isExists = (name: string) => (
+            variants.filter((v) => (v.name.trim() === name.trim())).length > 0
+        )
+    
+    return (
+        <div>
+            <DialogTitle>{t('title')}</DialogTitle>
+            <DialogContent>
+                <DialogContentText>{t('body')}</DialogContentText>
+                <Autocomplete
+                    sx={{ width: 350, margin: 5 }}
+                    options={variants}
+                    disableCloseOnSelect
+                    getOptionLabel={(option) => (typeof option === 'string' ?
+                        option : option.name)}
+                    value={value}
+                    inputValue={inputValue}
+                    onChange={handleChange}
+                    onInputChange={handleInputChange}
+                    isOptionEqualToValue={(option, value) => (option.name.trim() === value.name.trim())}
+                    freeSolo
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            size="small"
+                            sx={{ input: {
+                                color: isExists(inputValue) ? 'red' : 'green'
+                            } }}
+                            label={t("input_label")}
+                            inputProps={{
+                                ...params.inputProps,
+                                autoComplete: 'new-password',
+                            }}
+                            >
+                        </TextField>
+                    )}
+                />
+                {isExists(inputValue) ?
+                    <Typography color="red">{t("exists")}</Typography> : null}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={props.onCancel}>{t("cancel")}</Button>
+                <Button disabled={isExists(inputValue) || inputValue.trim() === ""}
+                onClick={() => {
+                    props.onSubmit(inputValue)
+                }}>{t("create")}</Button>
+            </DialogActions>
+        </div>
+    )
+}

--- a/frontend/src/FiltersTablePage/FilterTablePage.tsx
+++ b/frontend/src/FiltersTablePage/FilterTablePage.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "@mui/system";
-import { Card, Typography, IconButton, ListItem, List, TextField, TextFieldProps, Autocomplete, Button, Box } from "@mui/material";
+import { Card, Typography, IconButton, ListItem, List, TextField, TextFieldProps, Autocomplete, Button, Box, Dialog } from "@mui/material";
 import { AnswerType, SERVER_ADDRESS } from "../types/global"
 import ClearIcon from '@material-ui/icons/Clear'
 import AddIcon from '@material-ui/icons/Add'
@@ -14,6 +14,7 @@ import i18next from "i18next";
 import axios from "axios";
 import { Buffer } from "buffer";
 import { Link, useNavigate } from "react-router-dom";
+import AddObjectPopup from "./AddObjectPopup";
 
 interface QuestionAttributes {
     default_filter: boolean | null,
@@ -170,6 +171,7 @@ function FilterTablePage({ formType } : { formType: 'LEADER' | 'PROJECT' }) {
         headColumns: [],
         rows: []
     })
+    const [addDialogOpen, setAddDialogOpen] = useState<boolean>(false)
     const isInitialMount = useRef(true)
     const navigate = useNavigate()
 
@@ -334,10 +336,7 @@ function FilterTablePage({ formType } : { formType: 'LEADER' | 'PROJECT' }) {
             <Box>
                 <Button variant="contained" onClick={handleSubmitFilter} sx={{ m: 2 }}>{t('submit_filter')}</Button>
                 <Button variant="outlined" sx={{ m: 2 }} onClick={(event: React.MouseEvent) => {
-                    makeNewObject(navigate, formType).then((id) => {
-                        const link = '/' + formType.toLowerCase() + '/' + id
-                        navigate(link, { replace: true })
-                    })
+                    setAddDialogOpen(true)
                 }}>
                     {formType === 'LEADER' ? t('add_leader') : t('add_project')}
                 </Button>
@@ -346,6 +345,17 @@ function FilterTablePage({ formType } : { formType: 'LEADER' | 'PROJECT' }) {
             <Card>
                 <MainTable {...JSON.parse(JSON.stringify(tableData))}/>
             </Card>
+            <Dialog open={addDialogOpen}>
+                <AddObjectPopup onCancel={() => {
+                    setAddDialogOpen(false)
+                }} onSubmit={(name: string) => {
+                    setAddDialogOpen(false)
+                    makeNewObject(navigate, formType, name).then((id) => {
+                        const link = '/' + formType.toLowerCase() + '/' + id
+                        navigate(link, { replace: true })
+                    })
+                }} formType={formType}/>
+            </Dialog>
         </Stack>
     )
 }

--- a/frontend/src/FiltersTablePage/MainTable.tsx
+++ b/frontend/src/FiltersTablePage/MainTable.tsx
@@ -52,7 +52,6 @@ function getComparator(
 
 function stableSort(array: readonly Row[], comparator: (a: Row, b: Row) => number) {
     const stabilizedThis = array.map((el, index) => [el, index] as [Row, number]);
-    console.log("stabilizedThis:", array, stabilizedThis)
     stabilizedThis.sort((a, b) => {
       const order = comparator(a[0], b[0])
       if (order !== 0) {
@@ -60,7 +59,6 @@ function stableSort(array: readonly Row[], comparator: (a: Row, b: Row) => numbe
       }
       return a[1] - b[1];
     })
-    console.log("stabilizedThis sorted:", stabilizedThis)
     return stabilizedThis.map((el) => el[0]);
 }
 
@@ -139,7 +137,7 @@ function RenderRow(props: Row) {
         }
     }
 
-    props.columns = props.columns.map(col => col.filter((value, index) => {
+    const columns = props.columns.map(col => col.filter((value, index) => {
         if (col[index].data == "DELETED") {
             return false;
         }
@@ -154,7 +152,7 @@ function RenderRow(props: Row) {
     return (
         <TableRow>
             <StyledTableCell>{props.id}</StyledTableCell>
-            {props.columns.map((col) => {
+            {columns.map((col) => {
                 if (col.length === 1) {
                     return (
                         <StyledTableCell>
@@ -204,15 +202,9 @@ export default function MainTable(props: TableData) {
           setOrder(toggledOrder)
           setOrderBy(newOrderBy)
 
-          console.log("handleRequestSort:", visibleRows)
           const sortedRows = stableSort(visibleRows,
             getComparator(toggledOrder, newOrderBy));
-          const updatedRows = sortedRows.slice(
-            page * rowsPerPage,
-            page * rowsPerPage + rowsPerPage,
-          );
-          console.log("Sorted Rows:", sortedRows)
-          setVisibleRows(updatedRows);
+          setVisibleRows(sortedRows);
         }
 
     const head : HeadProps = {
@@ -223,15 +215,12 @@ export default function MainTable(props: TableData) {
     }
 
     useEffect(() => {
-        console.log("useEffect:", props.rows)
         const newRows : Row[] = props.rows.map(
             (row) => (JSON.parse(JSON.stringify(row)))
             )
         if (props.rows.length > 0) {
-            console.log("New Rows:", JSON.parse(JSON.stringify(props.rows)))
             setVisibleRows(JSON.parse(JSON.stringify(props.rows)))
         }
-        console.log("visibleRows:", visibleRows)
     }, [props.rows])
 
     return (
@@ -240,9 +229,9 @@ export default function MainTable(props: TableData) {
                 <Table size="small" stickyHeader>
                     <Head {...head}/>
                     <TableBody>
-                        {visibleRows
+                        {JSON.parse(JSON.stringify(visibleRows))
                             .slice(page * rowsPerPage, (page + 1) * rowsPerPage)
-                            .map((row: Row) => (<RenderRow {...row}/>))}
+                            .map((row: Row, index: number) => <RenderRow {...row}/>)}
                     </TableBody>
                 </Table>
             </TableContainer>


### PR DESCRIPTION
This PR includes:
1) fix bug with sorting main table (about sorting rows on the first page only)
2) popup dialog for adding new leader/project by clicking **ADD LEADER/PROJECT** button on the main page. It includes autocomplete and also prevents adding leader/project with existing name